### PR TITLE
docs: convert to archive style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![](https://heatbadger.now.sh/github/readme/contributte/thumbator/?deprecated=1)
+![](https://heatbadger.now.sh/github/readme/contributte/eet/?deprecated=1)
 
 <p align=center>
     <a href="https://bit.ly/ctteg"><img src="https://badgen.net/badge/support/gitter/cyan"></a>
@@ -15,7 +15,7 @@
 | :warning: | This project is no longer being maintained.
 |---|---|
 
-| Composer | [`contributte/eet`](https://packagist.org/contributte/eet) |
+| Composer | [`contributte/eet`](https://packagist.org/packages/contributte/eet) |
 |---|------------------------------------------------------------|
 | Version | ![](https://badgen.net/packagist/v/contributte/eet)      |
 | PHP | ![](https://badgen.net/packagist/php/contributte/eet)    |


### PR DESCRIPTION
## Summary

- Add deprecation badge with `?deprecated=1` parameter
- Fix heatbadger badge repo name from thumbator to eet
- Fix Packagist URL to use correct format with `/packages/`
- Repository follows template Option B (Without Replacement Package)
- Development section uses past tense ("was maintained")

## Changes

- Fixed deprecation badge URL to point to correct repo
- Corrected Composer package URL format
- All archive template requirements met

This repository is ready for archival following the standard Contributte archive template.

Generated with Claude Code